### PR TITLE
Rename Stream to Pipe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-Guidance for AI assistants working in **flowgraph**.
+Guidance for coding agents working in **flowgraph**.
 
 ## Commenting style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# CLAUDE.md
+
+Guidance for AI assistants working in **flowgraph**.
+
+## Commenting style
+
+- Two lines max per comment block. If it needs more, the identifier is
+  probably named wrong -- fix the name, not the comment.
+- Never reference issue or PR numbers in source comments. Rationale that
+  matters belongs in `DESIGN.md`, not tied to a tracker entry that outlives
+  the code differently than the code does.
+- Don't restate what the identifier already says. `// Pipe returns a pipe
+  by index` teaches nothing `Pipe(n int) Pipe` didn't already say -- delete
+  it or say something the signature can't.
+- Comment the non-obvious only: a naming decision, a subtle invariant, a
+  reason something is shaped the way it is. See `pipe.go`'s Stream->Pipe
+  note for the target length and tone.
+- Source is the documentation. See https://wiki.c2.com/?StudyTheSourceWithaDebugger.
+
+## Where design rationale goes
+
+Naming and architecture decisions that need more than two lines go in
+`DESIGN.md`, not inline. Keep entries as short as the reasoning allows.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ go test
 
 ### Overview
 
-Flowgraphs are built out of hubs interconnected by streams. The hubs are implemented with goroutines that use select to wait on incoming data or back-pressure handshakes. The data and handshakes travel on streams implemented with channels of empty interfaces for forward flow (interface{}) and channels of empty structs for back-pressure (struct{}).
+Flowgraphs are built out of hubs interconnected by pipes. The hubs are implemented with goroutines that use select to wait on incoming data or back-pressure handshakes. The data and handshakes travel on pipes implemented with channels of empty interfaces for forward flow (interface{}) and channels of empty structs for back-pressure (struct{}).
 
 The user of this package is completely isolated from the details of using goroutines, channels, and select, and only has to provide the empty interface functions that transform incoming data into outgoing data as needed for each hub of the flowgraph under construction. It includes the ability to log each data flow and transformation at the desired level of detail for debugging and monitoring purposes. 
 

--- a/duckpond/pond2x1.go
+++ b/duckpond/pond2x1.go
@@ -285,23 +285,23 @@ func main() {
 
 	fg := flowgraph.New("DuckPond2x1")
 
-	duckImport00 := fg.NewStream("duckImport00")
-	duckWait00 := fg.NewStream("duckWait00")
-	duckSinkW := fg.NewStream("duckSinkW").Init(&duck{-2, 0, "W", "W", false, false, -1, rand.Intn(1000)})
+	duckImport00 := fg.NewPipe("duckImport00")
+	duckWait00 := fg.NewPipe("duckWait00")
+	duckSinkW := fg.NewPipe("duckSinkW").Init(&duck{-2, 0, "W", "W", false, false, -1, rand.Intn(1000)})
 	duckFakeW := duckSinkW
 	if gridLock {
-		duckFakeW = fg.NewStream("duckFakeW").Const(&duck{-4, 0, "W", "W", false, false, -1, rand.Intn(1000)})
+		duckFakeW = fg.NewPipe("duckFakeW").Const(&duck{-4, 0, "W", "W", false, false, -1, rand.Intn(1000)})
 	}
-	duckExport00 := fg.NewStream("duckExport00")
+	duckExport00 := fg.NewPipe("duckExport00")
 
-	duckImport10 := fg.NewStream("duckImport10")
-	duckWait10 := fg.NewStream("duckWait10")
-	duckSinkE := fg.NewStream("duckSinkE").Init(&duck{-1, 0, "E", "E", false, false, -1, rand.Intn(1000)})
+	duckImport10 := fg.NewPipe("duckImport10")
+	duckWait10 := fg.NewPipe("duckWait10")
+	duckSinkE := fg.NewPipe("duckSinkE").Init(&duck{-1, 0, "E", "E", false, false, -1, rand.Intn(1000)})
 	duckFakeE := duckSinkE
 	if gridLock {
-		duckFakeE = fg.NewStream("duckFakeE").Const(&duck{-3, 0, "E", "E", false, false, -1, rand.Intn(1000)})
+		duckFakeE = fg.NewPipe("duckFakeE").Const(&duck{-3, 0, "E", "E", false, false, -1, rand.Intn(1000)})
 	}
-	duckExport10 := fg.NewStream("duckExport10")
+	duckExport10 := fg.NewPipe("duckExport10")
 
 	fg.NewHub("nestW", flowgraph.Retrieve, &nestC{rw: buffConn("localhost:20002"), loc: "W"}).
 		ConnectResults(duckWait00)

--- a/examples/chained.go
+++ b/examples/chained.go
@@ -35,32 +35,32 @@ func main() {
 
         fg := flowgraph.New("chained")
 
-	firstval1 := fg.NewStream("firstval1")
+	firstval1 := fg.NewPipe("firstval1")
 	fg.NewHub("ten", flowgraph.Retrieve, &ten{}).
 		ConnectResults(firstval1)
 
-	lastval1 := fg.NewStream("lastval1")
+	lastval1 := fg.NewPipe("lastval1")
 	while1 := fg.NewGraphHub("while1", flowgraph.While)
 	while1.ConnectSources(firstval1).
 		ConnectResults(lastval1)
 
-	oneval1 := while1.NewStream("oneval1").Const(1)
+	oneval1 := while1.NewPipe("oneval1").Const(1)
 	while1.NewHub("sub1", flowgraph.Subtract, nil).
 		ConnectSources(nil, oneval1)
 	while1.Loop()
 
-	tenval := fg.NewStream("tenval").Const(10)
-	firstval2 := fg.NewStream("firstval2")
+	tenval := fg.NewPipe("tenval").Const(10)
+	firstval2 := fg.NewPipe("firstval2")
 	fg.NewHub("wait", flowgraph.Wait, 1).
 		ConnectSources(tenval, lastval1).
 		ConnectResults(firstval2)
 
-	lastval2 := fg.NewStream("lastval2")
+	lastval2 := fg.NewPipe("lastval2")
 	while2 := fg.NewGraphHub("while2", flowgraph.While)
 	while2.ConnectSources(firstval2).
 		ConnectResults(lastval2)
 
-	oneval2 := while2.NewStream("oneval2").Const(1)
+	oneval2 := while2.NewPipe("oneval2").Const(1)
 	while2.NewHub("sub2", flowgraph.Subtract, nil).
 		ConnectSources(nil, oneval2)
 	while2.Loop()

--- a/examples/gcd.go
+++ b/examples/gcd.go
@@ -41,10 +41,10 @@ func main() {
 
 	fg := flowgraph.New("gcd")
 
-	mval := fg.NewStream("mval")
-	nval := fg.NewStream("nval")
-	tcond := fg.NewStream("tcond")
-	gcd := fg.NewStream("gcd")
+	mval := fg.NewPipe("mval")
+	nval := fg.NewPipe("nval")
+	tcond := fg.NewPipe("tcond")
+	gcd := fg.NewPipe("gcd")
 
 	fg.NewHub("rand100", flowgraph.Retrieve, &rand100{}).
 		ConnectResults(mval)

--- a/examples/loop2.go
+++ b/examples/loop2.go
@@ -41,11 +41,11 @@ func main() {
 
 	fg := flowgraph.New("loop2")
 
-	firstval := fg.NewStream("firstval")
-	lastval := fg.NewStream("lastval").Init(0)
-	oldval := fg.NewStream("oldval")
-	oneval := fg.NewStream("oneval").Const(1)
-	newval := fg.NewStream("newval")
+	firstval := fg.NewPipe("firstval")
+	lastval := fg.NewPipe("lastval").Init(0)
+	oldval := fg.NewPipe("oldval")
+	oneval := fg.NewPipe("oneval").Const(1)
+	newval := fg.NewPipe("newval")
 
 	fg.NewHub("ten", flowgraph.Constant, 10).
 		ConnectResults(firstval)

--- a/examples/loop3.go
+++ b/examples/loop3.go
@@ -42,8 +42,8 @@ func main() {
 
 	fg := flowgraph.New("loop3")
 
-	firstval := fg.NewStream("firstval")
-	lastval := fg.NewStream("lastval")
+	firstval := fg.NewPipe("firstval")
+	lastval := fg.NewPipe("lastval")
 
 	fg.NewHub("ten", flowgraph.Retrieve, &ten{}).
 		ConnectResults(firstval)
@@ -52,7 +52,7 @@ func main() {
 	while.ConnectSources(firstval).
 		ConnectResults(lastval)
 
-	oneval := while.NewStream("oneval").Const(1)
+	oneval := while.NewPipe("oneval").Const(1)
 	while.NewHub("sub", flowgraph.Subtract, nil).
 		ConnectSources(nil, oneval)
 	while.Loop()

--- a/examples/nested.go
+++ b/examples/nested.go
@@ -33,11 +33,11 @@ func main() {
 
 	fg := flowgraph.New("TestIterator5")
 
-	firstval1 := fg.NewStream("firstval1")
+	firstval1 := fg.NewPipe("firstval1")
 	fg.NewHub("ten", flowgraph.Retrieve, &ten{}).
 		ConnectResults(firstval1)
 
-	lastval1 := fg.NewStream("lastval1")
+	lastval1 := fg.NewPipe("lastval1")
 	while1 := fg.NewGraphHub("while1", flowgraph.While)
 	while1.ConnectSources(firstval1).
 		ConnectResults(lastval1)
@@ -46,7 +46,7 @@ func main() {
 	while2.SetNumSource(1).SetNumResult(1) // could be detected
 	while1.Loop()
 
-	oneval := while2.NewStream("oneval").Const(1)
+	oneval := while2.NewPipe("oneval").Const(1)
 	while2.NewHub("sub", flowgraph.Subtract, nil).
 		ConnectSources(nil, oneval)
 	while2.Loop()

--- a/flowgraph.go
+++ b/flowgraph.go
@@ -1,5 +1,5 @@
 // Package flowgraph for scalable asynchronous development.
-// Build systems out of hubs interconnected by streams of data.
+// Build systems out of hubs interconnected by pipes of data.
 // https://github.com/vectaport/flowgraph/wiki
 package flowgraph
 
@@ -30,7 +30,7 @@ func ParseFlags() {
 	fgbase.TraceStyle = fgbase.New
 }
 
-// Flowgraph interface for flowgraphs assembled out of hubs and streams
+// Flowgraph interface for flowgraphs assembled out of hubs and pipes
 type Flowgraph interface {
 
 	// Title returns the title of this flowgraph
@@ -39,20 +39,20 @@ type Flowgraph interface {
 	// Hub returns a hub by index
 	Hub(n int) Hub
 
-	// Stream returns a stream by index
-	Stream(n int) Stream
+	// Pipe returns a pipe by index
+	Pipe(n int) Pipe
 
 	// NumHub returns the number of hubs
 	NumHub() int
 
-	// NumStream returns the number of streams
-	NumStream() int
+	// NumPipe returns the number of pipes
+	NumPipe() int
 
 	// NewHub returns a new unconnected hub
 	NewHub(name string, code HubCode, init interface{}) Hub
 
-	// NewStream returns a new unconnected stream
-	NewStream(name string) Stream
+	// NewPipe returns a new unconnected pipe
+	NewPipe(name string) Pipe
 
 	// NewGraphHub returns a hub with a flowgraph inside
 	NewGraphHub(name string, code HubCode) GraphHub
@@ -60,38 +60,38 @@ type Flowgraph interface {
 	// FindHub finds a hub by name
 	FindHub(name string) Hub
 
-	// FindStream finds a stream by name
-	FindStream(name string) Stream
+	// FindPipe finds a pipe by name
+	FindPipe(name string) Pipe
 
 	// Connect connects two hubs via named (string) or indexed (int) ports
 	Connect(
 		upstream Hub, upstreamPort interface{},
-		dnstream Hub, dnstreamPort interface{}) Stream
+		dnstream Hub, dnstreamPort interface{}) Pipe
 
 	// ConnectInit connects two hubs via named (string) or indexed (int) ports
 	// and sets an initial value for flow
 	ConnectInit(
 		upstream Hub, upstreamPort interface{},
 		dnstream Hub, dnstreamPort interface{},
-		init interface{}) Stream
+		init interface{}) Pipe
 
 	// Run runs the flowgraph
 	Run()
 }
 
 type flowgraph struct {
-	title        string
-	hubs         []Hub
-	streams      []Stream
-	nameToHub    map[string]Hub
-	nameToStream map[string]Stream
+	title      string
+	hubs       []Hub
+	pipes      []Pipe
+	nameToHub  map[string]Hub
+	nameToPipe map[string]Pipe
 }
 
 // New returns a titled flowgraph
 func New(title string) Flowgraph {
 	nameToHub := make(map[string]Hub)
-	nameToStream := make(map[string]Stream)
-	fg := flowgraph{title, nil, nil, nameToHub, nameToStream}
+	nameToPipe := make(map[string]Pipe)
+	fg := flowgraph{title, nil, nil, nameToHub, nameToPipe}
 	return &fg
 }
 
@@ -105,9 +105,9 @@ func (fg *flowgraph) Hub(n int) Hub {
 	return fg.hubs[n]
 }
 
-// Stream returns a stream by index
-func (fg *flowgraph) Stream(n int) Stream {
-	return fg.streams[n]
+// Pipe returns a pipe by index
+func (fg *flowgraph) Pipe(n int) Pipe {
+	return fg.pipes[n]
 }
 
 // NumHub returns the number of hubs
@@ -115,9 +115,9 @@ func (fg *flowgraph) NumHub() int {
 	return len(fg.hubs)
 }
 
-// NumStream returns the number of hubs
-func (fg *flowgraph) NumStream() int {
-	return len(fg.streams)
+// NumPipe returns the number of hubs
+func (fg *flowgraph) NumPipe() int {
+	return len(fg.pipes)
 }
 
 type fgTransformer struct {
@@ -265,12 +265,12 @@ func (fg *flowgraph) NewHub(name string, code HubCode, init interface{}) Hub {
 	return h
 }
 
-// NewStream returns a new unconnected stream
-func (fg *flowgraph) NewStream(name string) Stream {
+// NewPipe returns a new unconnected pipe
+func (fg *flowgraph) NewPipe(name string) Pipe {
 	e := fgbase.MakeEdge(name, nil)
-	s := &stream{&e, fg}
-	fg.streams = append(fg.streams, s)
-	fg.nameToStream[name] = s
+	s := &pipe{&e, fg}
+	fg.pipes = append(fg.pipes, s)
+	fg.nameToPipe[name] = s
 	return s
 }
 
@@ -302,15 +302,15 @@ func (fg *flowgraph) FindHub(name string) Hub {
 	return fg.nameToHub[name]
 }
 
-// FindStream finds a Stream by name
-func (fg *flowgraph) FindStream(name string) Stream {
-	return fg.nameToStream[name]
+// FindPipe finds a Pipe by name
+func (fg *flowgraph) FindPipe(name string) Pipe {
+	return fg.nameToPipe[name]
 }
 
 // Connect connects two hubs via named (string) or indexed (int) ports
 func (fg *flowgraph) Connect(
 	upstream Hub, upstreamPort interface{},
-	dnstream Hub, dnstreamPort interface{}) Stream {
+	dnstream Hub, dnstreamPort interface{}) Pipe {
 	return fg.connectInit(upstream, upstreamPort, dnstream, dnstreamPort, nil)
 }
 
@@ -319,7 +319,7 @@ func (fg *flowgraph) Connect(
 func (fg *flowgraph) ConnectInit(
 	upstream Hub, upstreamPort interface{},
 	dnstream Hub, dnstreamPort interface{},
-	init interface{}) Stream {
+	init interface{}) Pipe {
 	return fg.connectInit(upstream, upstreamPort, dnstream, dnstreamPort, init)
 }
 
@@ -328,12 +328,12 @@ func (fg *flowgraph) ConnectInit(
 func (fg *flowgraph) connectInit(
 	upstream Hub, upstreamPort interface{},
 	dnstream Hub, dnstreamPort interface{},
-	init interface{}) Stream {
+	init interface{}) Pipe {
 
 	checkInternalHub(fg, upstream)
 	checkInternalHub(fg, dnstream)
 
-	var us Stream
+	var us Pipe
 	var usok bool
 	switch v := upstreamPort.(type) {
 	case string:
@@ -351,7 +351,7 @@ func (fg *flowgraph) connectInit(
 		upstream.Panicf("Need string or int to specify port on upstream Hub \"%s\"\n", upstream.Name())
 	}
 
-	var ds Stream
+	var ds Pipe
 	var dsok bool
 	switch v := dnstreamPort.(type) {
 	case string:
@@ -370,9 +370,9 @@ func (fg *flowgraph) connectInit(
 	}
 
 	if us.Empty() && ds.Empty() {
-		s := fg.NewStream("")
+		s := fg.NewPipe("")
 		s.Init(init)
-		fg.streams = append(fg.streams, s)
+		fg.pipes = append(fg.pipes, s)
 		upstream.SetResult(upstreamPort, s)
 		dnstream.SetSource(dnstreamPort, s)
 		return s
@@ -386,7 +386,7 @@ func (fg *flowgraph) connectInit(
 		return us
 	}
 	/*
-		upstream.Panicf("Unexpected that with two ports to connect (%s:%v(%s) and %s:%v(%s() that they both are already connected to another stream as well",
+		upstream.Panicf("Unexpected that with two ports to connect (%s:%v(%s) and %s:%v(%s() that they both are already connected to another pipe as well",
 			upstream.Name(), upstreamPort, us.Name(), dnstream.Name(), dnstreamPort, ds.Name())
 	*/
 	return nil
@@ -423,33 +423,33 @@ func checkExternalHub(fg Flowgraph, h Hub) {
 	}
 }
 
-// checkInternalStream checks that the flowgraph associated with a Stream matches
-func checkInternalStream(fg Flowgraph, s Stream) {
+// checkInternalPipe checks that the flowgraph associated with a Pipe matches
+func checkInternalPipe(fg Flowgraph, s Pipe) {
 	if s == nil {
 		return
 	}
 	fgknown := fg
 	fgtest := s.Flowgraph()
 	if fgknown != fgtest {
-		panic(fmt.Sprintf("Stream %q created by flowgraph %q (expected it to be created by flowgraph %q)",
+		panic(fmt.Sprintf("Pipe %q created by flowgraph %q (expected it to be created by flowgraph %q)",
 			s.Name(), fgtest.Title(), fgknown.Title()))
 	}
 }
 
-// checkExternalStream checks that the flowgraph associated with a Stream doesn't match
-func checkExternalStream(fg Flowgraph, s Stream) {
+// checkExternalPipe checks that the flowgraph associated with a Pipe doesn't match
+func checkExternalPipe(fg Flowgraph, s Pipe) {
 	if s == nil {
 		return
 	}
 	fgknown := fg
 	fgtest := s.Flowgraph()
 	if fgknown == fgtest {
-		panic(fmt.Sprintf("External Stream %q created by same flowgraph %q",
+		panic(fmt.Sprintf("External Pipe %q created by same flowgraph %q",
 			s.Name(), fgtest.Title()))
 	}
 }
 
-// flatten connects GraphHub external ports to internal dangling streams
+// flatten connects GraphHub external ports to internal dangling pipes
 func (fg *flowgraph) flatten() []*fgbase.Node {
 	if flatDot {
 		fgbase.DotOutput = true

--- a/flowgraph_test.go
+++ b/flowgraph_test.go
@@ -284,11 +284,11 @@ func TestDotNaming(t *testing.T) {
 	fg.Connect(h0, "XYZ", h1, "ABC")
 
 	if h0.Result(0).Empty() {
-		t.Fatalf("ERROR Unable to find stream at result port numbered 0 on hub %s\n", h0.Name())
+		t.Fatalf("ERROR Unable to find pipe at result port numbered 0 on hub %s\n", h0.Name())
 	}
 
 	if h1.Source(0).Empty() {
-		t.Fatalf("ERROR Unable to find stream at source port numbered 0\n")
+		t.Fatalf("ERROR Unable to find pipe at source port numbered 0\n")
 	}
 
 	fg.Run()
@@ -617,11 +617,11 @@ func TestIterator2(t *testing.T) {
 
 	fg := flowgraph.New("TestIterator2")
 
-	firstval := fg.NewStream("firstval")
-	lastval := fg.NewStream("lastval").Init(0)
-	oldval := fg.NewStream("oldval")
-	oneval := fg.NewStream("oneval").Const(1)
-	newval := fg.NewStream("newval")
+	firstval := fg.NewPipe("firstval")
+	lastval := fg.NewPipe("lastval").Init(0)
+	oldval := fg.NewPipe("oldval")
+	oneval := fg.NewPipe("oneval").Const(1)
+	newval := fg.NewPipe("newval")
 
 	fg.NewHub("ten", flowgraph.Constant, 10).
 		ConnectResults(firstval)
@@ -682,8 +682,8 @@ func TestIterator3(t *testing.T) {
 
 	fg := flowgraph.New("TestIterator3")
 
-	firstval := fg.NewStream("firstval")
-	lastval := fg.NewStream("lastval")
+	firstval := fg.NewPipe("firstval")
+	lastval := fg.NewPipe("lastval")
 
 	fg.NewHub("ten", flowgraph.Retrieve, &ten{}).
 		ConnectResults(firstval)
@@ -692,7 +692,7 @@ func TestIterator3(t *testing.T) {
 	while.ConnectSources(firstval).
 		ConnectResults(lastval)
 
-	oneval := while.NewStream("oneval").Const(1)
+	oneval := while.NewPipe("oneval").Const(1)
 	while.NewHub("sub", flowgraph.Subtract, nil).
 		ConnectSources(nil, oneval)
 	while.Loop()
@@ -733,32 +733,32 @@ func TestIterator4(t *testing.T) {
 
 	fg := flowgraph.New("TestIterator4")
 
-	firstval1 := fg.NewStream("firstval1")
+	firstval1 := fg.NewPipe("firstval1")
 	fg.NewHub("ten", flowgraph.Retrieve, &ten{}).
 		ConnectResults(firstval1)
 
-	lastval1 := fg.NewStream("lastval1")
+	lastval1 := fg.NewPipe("lastval1")
 	while1 := fg.NewGraphHub("while1", flowgraph.While)
 	while1.ConnectSources(firstval1).
 		ConnectResults(lastval1)
 
-	oneval1 := while1.NewStream("oneval1").Const(1)
+	oneval1 := while1.NewPipe("oneval1").Const(1)
 	while1.NewHub("sub1", flowgraph.Subtract, nil).
 		ConnectSources(nil, oneval1)
 	while1.Loop()
 
-	tenval := fg.NewStream("tenval").Const(10)
-	firstval2 := fg.NewStream("firstval2")
+	tenval := fg.NewPipe("tenval").Const(10)
+	firstval2 := fg.NewPipe("firstval2")
 	fg.NewHub("wait", flowgraph.Wait, 1).
 		ConnectSources(tenval, lastval1).
 		ConnectResults(firstval2)
 
-	lastval2 := fg.NewStream("lastval2")
+	lastval2 := fg.NewPipe("lastval2")
 	while2 := fg.NewGraphHub("while2", flowgraph.While)
 	while2.ConnectSources(firstval2).
 		ConnectResults(lastval2)
 
-	oneval2 := while2.NewStream("oneval2").Const(1)
+	oneval2 := while2.NewPipe("oneval2").Const(1)
 	while2.NewHub("sub2", flowgraph.Subtract, nil).
 		ConnectSources(nil, oneval2)
 	while2.Loop()
@@ -796,11 +796,11 @@ func TestIterator5(t *testing.T) {
 
 	fg := flowgraph.New("TestIterator5")
 
-	firstval1 := fg.NewStream("firstval1")
+	firstval1 := fg.NewPipe("firstval1")
 	fg.NewHub("ten", flowgraph.Retrieve, &ten{}).
 		ConnectResults(firstval1)
 
-	lastval1 := fg.NewStream("lastval1")
+	lastval1 := fg.NewPipe("lastval1")
 	while1 := fg.NewGraphHub("while1", flowgraph.While)
 	while1.ConnectSources(firstval1).
 		ConnectResults(lastval1)
@@ -809,7 +809,7 @@ func TestIterator5(t *testing.T) {
 	while2.SetNumSource(1).SetNumResult(1) // could be detected
 	while1.Loop()
 
-	oneval := while2.NewStream("oneval").Const(1)
+	oneval := while2.NewPipe("oneval").Const(1)
 	while2.NewHub("sub", flowgraph.Subtract, nil).
 		ConnectSources(nil, oneval)
 	while2.Loop()
@@ -849,11 +849,11 @@ func TestIterator6(t *testing.T) {
 
 	fg := flowgraph.New("TestIterator6")
 
-	firstval1 := fg.NewStream("firstval1")
+	firstval1 := fg.NewPipe("firstval1")
 	fg.NewHub("ten", flowgraph.Retrieve, &ten{}).
 		ConnectResults(firstval1)
 
-	lastval1 := fg.NewStream("lastval1")
+	lastval1 := fg.NewPipe("lastval1")
 	while1 := fg.NewGraphHub("while1", flowgraph.While)
 	while1.ConnectSources(firstval1).
 		ConnectResults(lastval1)
@@ -866,7 +866,7 @@ func TestIterator6(t *testing.T) {
 	while3.SetNumSource(1).SetNumResult(1) // could be detected
 	while2.Loop()
 
-	oneval := while3.NewStream("oneval").Const(1)
+	oneval := while3.NewPipe("oneval").Const(1)
 	while3.NewHub("sub", flowgraph.Subtract, nil).
 		ConnectSources(nil, oneval)
 	while3.Loop()
@@ -908,11 +908,11 @@ func TestIterator7(t *testing.T) {
 
 	fg := flowgraph.New("TestIterator7")
 
-	firstval := fg.NewStream("firstval")
+	firstval := fg.NewPipe("firstval")
 	fg.NewHub("ten", flowgraph.Retrieve, &ten{}).
 		ConnectResults(firstval)
 
-	lastval := fg.NewStream("lastval")
+	lastval := fg.NewPipe("lastval")
 	while1 := fg.NewGraphHub("while1", flowgraph.While)
 	while1.ConnectSources(firstval).
 		ConnectResults(lastval)
@@ -929,7 +929,7 @@ func TestIterator7(t *testing.T) {
 	while4.SetNumSource(1).SetNumResult(1) // could be detected
 	while3.Loop()
 
-	oneval := while4.NewStream("oneval").Const(1)
+	oneval := while4.NewPipe("oneval").Const(1)
 	while4.NewHub("sub", flowgraph.Subtract, nil).
 		ConnectSources(nil, oneval)
 	while4.Loop()
@@ -972,24 +972,24 @@ func TestIterator8(t *testing.T) {
 
 	fg := flowgraph.New("TestIterator8")
 
-	firstval := fg.NewStream("firstval")
+	firstval := fg.NewPipe("firstval")
 	fg.NewHub("ten", flowgraph.Retrieve, &ten{}).
 		ConnectResults(firstval)
 
-	lastval := fg.NewStream("lastval")
+	lastval := fg.NewPipe("lastval")
 	while1 := fg.NewGraphHub("while1", flowgraph.While)
 	while1.ConnectSources(firstval).
 		ConnectResults(lastval)
 
 	while2 := while1.NewGraphHub("while2", flowgraph.While)
 	while2.SetNumSource(1).SetNumResult(1) // could be detected
-	oneval := while1.NewStream("oneval").Const(1)
+	oneval := while1.NewPipe("oneval").Const(1)
 	add := while1.NewHub("add", flowgraph.Add, nil).
 		ConnectSources(nil, oneval)
 	while1.Connect(add, 0, while2, 0).SetName("bumpval")
 	while1.Loop()
 
-	oneval2 := while2.NewStream("oneval2").Const(1)
+	oneval2 := while2.NewPipe("oneval2").Const(1)
 	while2.NewHub("sub", flowgraph.Subtract, nil).
 		ConnectSources(nil, oneval2)
 	while2.Loop()
@@ -1063,8 +1063,8 @@ func TestIterator9(t *testing.T) {
 
 	fg := flowgraph.New("TestIterator9")
 
-	firstval := fg.NewStream("firstval")
-	lastval := fg.NewStream("lastval")
+	firstval := fg.NewPipe("firstval")
+	lastval := fg.NewPipe("lastval")
 
 	fg.NewHub("tbtens", flowgraph.Retrieve, &tbtens{}).
 		ConnectResults(firstval)
@@ -1073,7 +1073,7 @@ func TestIterator9(t *testing.T) {
 	while.ConnectSources(firstval).
 		ConnectResults(lastval)
 
-	oneval := while.NewStream("oneval").Const(1)
+	oneval := while.NewPipe("oneval").Const(1)
 	while.NewHub("subber", flowgraph.AllOf, &subber{}).
 		ConnectSources(nil, oneval).
 		SetNumResult(1)
@@ -1125,10 +1125,10 @@ func TestGCD(t *testing.T) {
 
 	fg := flowgraph.New("TestGCD")
 
-	mval := fg.NewStream("mval")
-	nval := fg.NewStream("nval")
-	tcond := fg.NewStream("tcond")
-	gcd := fg.NewStream("gcd")
+	mval := fg.NewPipe("mval")
+	nval := fg.NewPipe("nval")
+	tcond := fg.NewPipe("tcond")
+	gcd := fg.NewPipe("gcd")
 
 	fg.NewHub("rand100", flowgraph.Retrieve, &rand100{}).
 		ConnectResults(mval)
@@ -1217,19 +1217,19 @@ func TestGoRound(t *testing.T) {
 
 	fg := flowgraph.New("TestGoRound")
 
-	ival := fg.NewStream("ival")
-	jval := fg.NewStream("jval")
-	kval := fg.NewStream("kval")
-	lval := fg.NewStream("lval")
-	mval := fg.NewStream("mval")
-	nval := fg.NewStream("nval")
+	ival := fg.NewPipe("ival")
+	jval := fg.NewPipe("jval")
+	kval := fg.NewPipe("kval")
+	lval := fg.NewPipe("lval")
+	mval := fg.NewPipe("mval")
+	nval := fg.NewPipe("nval")
 
-	iout := fg.NewStream("iout")
-	jout := fg.NewStream("jout")
-	kout := fg.NewStream("kout")
-	lout := fg.NewStream("lout")
-	mout := fg.NewStream("mout")
-	nout := fg.NewStream("nout")
+	iout := fg.NewPipe("iout")
+	jout := fg.NewPipe("jout")
+	kout := fg.NewPipe("kout")
+	lout := fg.NewPipe("lout")
+	mout := fg.NewPipe("mout")
+	nout := fg.NewPipe("nout")
 
 	fg.NewHub("tbcar", flowgraph.Retrieve, &tbcar{}).
 		ConnectResults(ival)
@@ -1304,14 +1304,14 @@ func TestCross(t *testing.T) {
 
 	fg := flowgraph.New("TestCross")
 
-	ival := fg.NewStream("ival")
-	jval := fg.NewStream("jval")
-	kval := fg.NewStream("kval")
-	lval := fg.NewStream("lval")
-	iout := fg.NewStream("iout")
-	jout := fg.NewStream("jout")
-	kout := fg.NewStream("kout")
-	lout := fg.NewStream("lout")
+	ival := fg.NewPipe("ival")
+	jval := fg.NewPipe("jval")
+	kval := fg.NewPipe("kval")
+	lval := fg.NewPipe("lval")
+	iout := fg.NewPipe("iout")
+	jout := fg.NewPipe("jout")
+	kout := fg.NewPipe("kout")
+	lout := fg.NewPipe("lout")
 
 	fg.NewHub("tbtoggle", flowgraph.Retrieve, &tbtoggle{}).
 		ConnectResults(ival)
@@ -1419,11 +1419,11 @@ func TestDuckPondA(t *testing.T) {
 
 	fg := flowgraph.New("TestDuckPondA")
 
-	newduck := fg.NewStream("newduck")
+	newduck := fg.NewPipe("newduck")
 	fg.NewHub("nest", flowgraph.Retrieve, &nest{}).
 		ConnectResults(newduck)
 
-	oldduck := fg.NewStream("oldduck")
+	oldduck := fg.NewPipe("oldduck")
 	pond := fg.NewGraphHub("pond", flowgraph.While)
 	pond.ConnectSources(newduck).ConnectResults(oldduck)
 
@@ -1498,13 +1498,13 @@ func TestDuckPondB(t *testing.T) {
 
 	fg := flowgraph.New("TestDuckPondB")
 
-	duckNW := fg.NewStream("duckNW")
+	duckNW := fg.NewPipe("duckNW")
 	fg.NewHub("nestN", flowgraph.Retrieve, &nest{}).
 		ConnectResults(duckNW)
 	fg.NewHub("nestW", flowgraph.Retrieve, &nest{}).
 		ConnectResults(duckNW)
 
-	duckSE := fg.NewStream("duckSE")
+	duckSE := fg.NewPipe("duckSE")
 	pond := fg.NewGraphHub("pond", flowgraph.While)
 	pond.ConnectSources(duckNW).ConnectResults(duckSE)
 
@@ -1512,8 +1512,8 @@ func TestDuckPondB(t *testing.T) {
 		SetNumSource(1).SetNumResult(1)
 	pond.Loop()
 
-	duckS := fg.NewStream("duckS")
-	duckE := fg.NewStream("duckE")
+	duckS := fg.NewPipe("duckS")
+	duckE := fg.NewPipe("duckE")
 	fg.NewHub("steer", flowgraph.AllOf, &steerDuck{}).
 		ConnectSources(duckSE).ConnectResults(duckS, duckE)
 

--- a/graphhub.go
+++ b/graphhub.go
@@ -15,22 +15,22 @@ type GraphHub interface {
 	// Loop builds a conditional iterator for a while or during loop
 	Loop()
 
-	// Link links an internal stream to an external stream
-	Link(in, ex Stream)
+	// Link links an internal pipe to an external pipe
+	Link(in, ex Pipe)
 
-	// ExposeSource marks an internal stream to be used as an input source as well
-	ExposeSource(s Stream)
+	// ExposeSource marks an internal pipe to be used as an input source as well
+	ExposeSource(s Pipe)
 
-	// ExposeResult marks an internal stream to be used as an output result as well
-	ExposeResult(s Stream)
+	// ExposeResult marks an internal pipe to be used as an output result as well
+	ExposeResult(s Pipe)
 }
 
 // GraphHub implementation
 type graphhub struct {
 	hub      Hub
 	fg       Flowgraph
-	isources []Stream
-	iresults []Stream
+	isources []Pipe
+	iresults []Pipe
 }
 
 // Title returns the title of this flowgraph
@@ -53,9 +53,9 @@ func (gh *graphhub) Hub(n int) Hub {
 	return gh.fg.Hub(n)
 }
 
-// Stream returns a stream by index
-func (gh *graphhub) Stream(n int) Stream {
-	return gh.fg.Stream(n)
+// Pipe returns a pipe by index
+func (gh *graphhub) Pipe(n int) Pipe {
+	return gh.fg.Pipe(n)
 }
 
 // NumHub returns the number of hubs
@@ -63,9 +63,9 @@ func (gh *graphhub) NumHub() int {
 	return gh.fg.NumHub()
 }
 
-// NumStream returns the number of streams
-func (gh *graphhub) NumStream() int {
-	return gh.fg.NumStream()
+// NumPipe returns the number of pipes
+func (gh *graphhub) NumPipe() int {
+	return gh.fg.NumPipe()
 }
 
 // NewHub returns a new unconnected hub
@@ -73,9 +73,9 @@ func (gh *graphhub) NewHub(name string, code HubCode, init interface{}) Hub {
 	return gh.fg.NewHub(name, code, init)
 }
 
-// NewStream returns a new unconnected stream
-func (gh *graphhub) NewStream(name string) Stream {
-	return gh.fg.NewStream(name)
+// NewPipe returns a new unconnected pipe
+func (gh *graphhub) NewPipe(name string) Pipe {
+	return gh.fg.NewPipe(name)
 }
 
 // NewGraphHub returns a hub with a sub-graph
@@ -88,15 +88,15 @@ func (gh *graphhub) FindHub(name string) Hub {
 	return gh.fg.FindHub(name)
 }
 
-// FindStream finds a stream by name
-func (gh *graphhub) FindStream(name string) Stream {
-	return gh.fg.FindStream(name)
+// FindPipe finds a pipe by name
+func (gh *graphhub) FindPipe(name string) Pipe {
+	return gh.fg.FindPipe(name)
 }
 
 // Connect connects two hubs via named (string) or indexed (int) ports
 func (gh *graphhub) Connect(
 	upstream Hub, upstreamPort interface{},
-	dnstream Hub, dnstreamPort interface{}) Stream {
+	dnstream Hub, dnstreamPort interface{}) Pipe {
 	return gh.fg.Connect(upstream, upstreamPort, dnstream, dnstreamPort)
 }
 
@@ -105,7 +105,7 @@ func (gh *graphhub) Connect(
 func (gh *graphhub) ConnectInit(
 	upstream Hub, upstreamPort interface{},
 	dnstream Hub, dnstreamPort interface{},
-	init interface{}) Stream {
+	init interface{}) Pipe {
 	return gh.fg.ConnectInit(upstream, upstreamPort, dnstream, dnstreamPort, init)
 }
 
@@ -129,33 +129,33 @@ func (gh *graphhub) Panicf(format string, v ...interface{}) {
 	gh.hub.Panicf(format, v...)
 }
 
-// Source returns source stream selected by string or int
-func (gh *graphhub) Source(port interface{}) Stream {
+// Source returns source pipe selected by string or int
+func (gh *graphhub) Source(port interface{}) Pipe {
 	return gh.hub.Source(port)
 }
 
-// Result returns result stream selected by string or int
-func (gh *graphhub) Result(port interface{}) Stream {
+// Result returns result pipe selected by string or int
+func (gh *graphhub) Result(port interface{}) Pipe {
 	return gh.hub.Result(port)
 }
 
-// SetSource sets a stream on a source port selected by string or int
-func (gh *graphhub) SetSource(port interface{}, s Stream) Hub {
+// SetSource sets a pipe on a source port selected by string or int
+func (gh *graphhub) SetSource(port interface{}, s Pipe) Hub {
 	return gh.hub.SetSource(port, s)
 }
 
-// SetResult sets a stream on a result port selected by string or int
-func (gh *graphhub) SetResult(port interface{}, s Stream) Hub {
+// SetResult sets a pipe on a result port selected by string or int
+func (gh *graphhub) SetResult(port interface{}, s Pipe) Hub {
 	return gh.hub.SetResult(port, s)
 }
 
-// AddSources adds a source port for each stream
-func (gh *graphhub) AddSources(s ...Stream) Hub {
+// AddSources adds a source port for each pipe
+func (gh *graphhub) AddSources(s ...Pipe) Hub {
 	return gh.hub.AddSources(s...)
 }
 
-// AddResults adds a result port for each stream
-func (gh *graphhub) AddResults(s ...Stream) Hub {
+// AddResults adds a result port for each pipe
+func (gh *graphhub) AddResults(s ...Pipe) Hub {
 	return gh.hub.AddResults(s...)
 }
 
@@ -199,23 +199,23 @@ func (gh *graphhub) SetResultNames(nm ...string) Hub {
 	return gh.hub.SetResultNames(nm...)
 }
 
-// SourceIndex returns the index of a source port selected by string or Stream
+// SourceIndex returns the index of a source port selected by string or Pipe
 func (gh *graphhub) SourceIndex(port interface{}) int {
 	return gh.hub.SourceIndex(port)
 }
 
-// ResultIndex returns the index of a source port selected by string or Stream
+// ResultIndex returns the index of a source port selected by string or Pipe
 func (gh *graphhub) ResultIndex(port interface{}) int {
 	return gh.hub.ResultIndex(port)
 }
 
-// ConnectSources connects a list of source streams to this hub
-func (gh *graphhub) ConnectSources(source ...Stream) Hub {
+// ConnectSources connects a list of source pipes to this hub
+func (gh *graphhub) ConnectSources(source ...Pipe) Hub {
 	return gh.hub.ConnectSources(source...)
 }
 
-// ConnectResults connects a list of result streams to this hub
-func (gh *graphhub) ConnectResults(result ...Stream) Hub {
+// ConnectResults connects a list of result pipes to this hub
+func (gh *graphhub) ConnectResults(result ...Pipe) Hub {
 	return gh.hub.ConnectResults(result...)
 
 }
@@ -339,30 +339,30 @@ func (gh *graphhub) Loop() {
 
 }
 
-// Link links an internal stream to an external stream
-func (gh *graphhub) Link(in, ex Stream) {
+// Link links an internal pipe to an external pipe
+func (gh *graphhub) Link(in, ex Pipe) {
 
-	checkInternalStream(gh.fg, in)
-	checkExternalStream(gh.fg, ex)
+	checkInternalPipe(gh.fg, in)
+	checkExternalPipe(gh.fg, ex)
 
 	ein := in.Base().(*fgbase.Edge)
 	eex := ex.Base().(*fgbase.Edge)
 	gh.Base().(*fgbase.Node).Link(ein, eex)
 }
 
-// ExposeSource marks an internal stream to be used as an input source as well
-func (gh *graphhub) ExposeSource(s Stream) {
-	checkInternalStream(gh.fg, s)
+// ExposeSource marks an internal pipe to be used as an input source as well
+func (gh *graphhub) ExposeSource(s Pipe) {
+	checkInternalPipe(gh.fg, s)
 	gh.isources = append(gh.isources, s)
 }
 
-// ExposeResult marks an internal stream to be used as an output source as well
-func (gh *graphhub) ExposeResult(s Stream) {
-	checkInternalStream(gh.fg, s)
+// ExposeResult marks an internal pipe to be used as an output source as well
+func (gh *graphhub) ExposeResult(s Pipe) {
+	checkInternalPipe(gh.fg, s)
 	gh.iresults = append(gh.iresults, s)
 }
 
-// flatten connects graphhub external ports to internal dangling streams
+// flatten connects graphhub external ports to internal dangling pipes
 func (gh *graphhub) flatten(nodes []*fgbase.Node) []*fgbase.Node {
 
 	debug := false
@@ -382,9 +382,9 @@ func (gh *graphhub) flatten(nodes []*fgbase.Node) []*fgbase.Node {
 		for i := 0; i < v.NumSource(); i++ {
 			s := v.Source(i)
 			if s.Empty() {
-				s = gh.NewStream("")
+				s = gh.NewPipe("")
 				v.SetSource(i, s)
-				// gh.Tracef("Making stub source stream %q with *Edge %p\n", s.Name(), s.Base().(*fgbase.Edge))
+				// gh.Tracef("Making stub source pipe %q with *Edge %p\n", s.Name(), s.Base().(*fgbase.Edge))
 				gh.isources = append(gh.isources, v.Source(i))
 				ns++
 			}
@@ -392,9 +392,9 @@ func (gh *graphhub) flatten(nodes []*fgbase.Node) []*fgbase.Node {
 		for i := 0; i < v.NumResult(); i++ {
 			r := v.Result(i)
 			if r.Empty() {
-				r = gh.NewStream("")
+				r = gh.NewPipe("")
 				v.SetResult(i, r)
-				// gh.Tracef("Making stub result stream %q with *Edge %p\n", r.Name(), r.Base().(*fgbase.Edge))
+				// gh.Tracef("Making stub result pipe %q with *Edge %p\n", r.Name(), r.Base().(*fgbase.Edge))
 				gh.iresults = append(gh.iresults, v.Result(i))
 				nr++
 			}
@@ -416,12 +416,12 @@ func (gh *graphhub) flatten(nodes []*fgbase.Node) []*fgbase.Node {
 	// dangling inputs
 	for i, s := range gh.isources {
 		if fgbase.TraceLevel >= fgbase.V {
-			fmt.Printf("// Source stream %q on outer hub \"%s\"\n", gh.Source(i).Name(), gh.Name())
+			fmt.Printf("// Source pipe %q on outer hub \"%s\"\n", gh.Source(i).Name(), gh.Name())
 		}
 		jmax := s.NumDownstream()
 		for j := 0; j < jmax; j++ {
 			if fgbase.TraceLevel >= fgbase.V {
-				fmt.Printf("// \tlinked by source stream %q that ends at hub %q port %v\n", s.Name(), s.Downstream(j).Name(), s.Downstream(j).SourceIndex(s))
+				fmt.Printf("// \tlinked by source pipe %q that ends at hub %q port %v\n", s.Name(), s.Downstream(j).Name(), s.Downstream(j).SourceIndex(s))
 			}
 			gh.Link(s, gh.Source(i))
 			if fgbase.DotOutput {
@@ -453,8 +453,8 @@ func (gh *graphhub) flatten(nodes []*fgbase.Node) []*fgbase.Node {
 	// dangling or designated outputs
 	for i, r := range gh.iresults {
 		if fgbase.TraceLevel >= fgbase.V {
-			fmt.Printf("// Result stream %q that starts at hub %q port %v\n", r.Name(), r.Upstream(0).Name(), r.Upstream(0).ResultIndex(r))
-			fmt.Printf("// \tlinked by result stream %q on outer hub %q\n", gh.Result(i).Name(), gh.Name())
+			fmt.Printf("// Result pipe %q that starts at hub %q port %v\n", r.Name(), r.Upstream(0).Name(), r.Upstream(0).ResultIndex(r))
+			fmt.Printf("// \tlinked by result pipe %q on outer hub %q\n", gh.Result(i).Name(), gh.Name())
 		}
 		jmax := r.NumUpstream()
 		for j := 0; j < jmax; j++ {

--- a/hub.go
+++ b/hub.go
@@ -4,7 +4,7 @@ import (
 	"github.com/vectaport/fgbase"
 )
 
-// Hub interface for flowgraph hubs that are connected by flowgraph streams
+// Hub interface for flowgraph hubs that are connected by flowgraph pipes
 type Hub interface {
 
 	// Name returns the hub name
@@ -22,23 +22,23 @@ type Hub interface {
 	// Panicf for logging of panic messages.  Uses atomic log mechanism.
 	Panicf(format string, v ...interface{})
 
-	// Source returns source stream selected by string or int
-	Source(port interface{}) Stream
+	// Source returns source pipe selected by string or int
+	Source(port interface{}) Pipe
 
-	// Result returns result stream selected by string or int
-	Result(port interface{}) Stream
+	// Result returns result pipe selected by string or int
+	Result(port interface{}) Pipe
 
-	// SetSource sets a stream on a source port selected by string or int
-	SetSource(port interface{}, s Stream) Hub
+	// SetSource sets a pipe on a source port selected by string or int
+	SetSource(port interface{}, s Pipe) Hub
 
-	// SetResult sets a stream on a result port selected by string or int
-	SetResult(port interface{}, s Stream) Hub
+	// SetResult sets a pipe on a result port selected by string or int
+	SetResult(port interface{}, s Pipe) Hub
 
-	// AddSources adds a source port for each stream
-	AddSources(s ...Stream) Hub
+	// AddSources adds a source port for each pipe
+	AddSources(s ...Pipe) Hub
 
-	// AddResults adds a result port for each stream
-	AddResults(s ...Stream) Hub
+	// AddResults adds a result port for each pipe
+	AddResults(s ...Pipe) Hub
 
 	// NumSource returns the number of source ports
 	NumSource() int
@@ -64,17 +64,17 @@ type Hub interface {
 	// SetResultNames names the result ports
 	SetResultNames(nm ...string) Hub
 
-	// SourceIndex returns the index of a source port selected by string or Stream
+	// SourceIndex returns the index of a source port selected by string or Pipe
 	SourceIndex(port interface{}) int
 
-	// ResultIndex returns the index of a result port selected by string or Stream
+	// ResultIndex returns the index of a result port selected by string or Pipe
 	ResultIndex(port interface{}) int
 
-	// ConnectSources connects a list of source Streams to this hub
-	ConnectSources(source ...Stream) Hub
+	// ConnectSources connects a list of source Pipes to this hub
+	ConnectSources(source ...Pipe) Hub
 
-	// ConnectResults connects a list of result Streams to this hub
-	ConnectResults(result ...Stream) Hub
+	// ConnectResults connects a list of result Pipes to this hub
+	ConnectResults(result ...Pipe) Hub
 
 	// HubCode returns code associated with hub.
 	HubCode() HubCode
@@ -121,8 +121,8 @@ func (h *hub) SetName(name string) {
 	h.base.Name = name
 }
 
-// Source returns source stream selected by int or string
-func (h *hub) Source(port interface{}) Stream {
+// Source returns source pipe selected by int or string
+func (h *hub) Source(port interface{}) Pipe {
 	var i int
 	var ok bool
 	switch v := port.(type) {
@@ -133,18 +133,18 @@ func (h *hub) Source(port interface{}) Stream {
 		ok = v >= 0 && v < h.NumSource()
 		i = v
 	default:
-		h.Panicf("Need string or int to select port on Hub %s to get source stream\n", h.Name())
+		h.Panicf("Need string or int to select port on Hub %s to get source pipe\n", h.Name())
 	}
 
 	if !ok {
 		h.Panicf("Source port %v not found on Hub %v\n", port, h.Name())
 	}
 
-	return &stream{h.base.Src(i), h.fg}
+	return &pipe{h.base.Src(i), h.fg}
 }
 
-// Result returns result stream selected by int or string
-func (h *hub) Result(port interface{}) Stream {
+// Result returns result pipe selected by int or string
+func (h *hub) Result(port interface{}) Pipe {
 	var i int
 	var ok bool
 	switch v := port.(type) {
@@ -155,19 +155,19 @@ func (h *hub) Result(port interface{}) Stream {
 		ok = v >= 0 && v < h.NumResult()
 		i = v
 	default:
-		h.Panicf("Need string or int to select port on Hub %s to get result stream\n", h.Name())
+		h.Panicf("Need string or int to select port on Hub %s to get result pipe\n", h.Name())
 	}
 
 	if !ok {
 		h.Panicf("Result port %v not found on Hub %v\n", port, h.Name())
 	}
 
-	return &stream{h.base.Dst(i), h.fg}
+	return &pipe{h.base.Dst(i), h.fg}
 }
 
-// SetSource sets a stream on a source port selected by string or int
-func (h *hub) SetSource(port interface{}, s Stream) Hub {
-	checkInternalStream(h.Flowgraph(), s)
+// SetSource sets a pipe on a source port selected by string or int
+func (h *hub) SetSource(port interface{}, s Pipe) Hub {
+	checkInternalPipe(h.Flowgraph(), s)
 
 	var i int
 	var ok bool
@@ -179,7 +179,7 @@ func (h *hub) SetSource(port interface{}, s Stream) Hub {
 		ok = v >= 0 && v < h.NumSource()
 		i = v
 	default:
-		h.Panicf("Need string or int to select port on Hub %s to set source stream\n", h.Name())
+		h.Panicf("Need string or int to select port on Hub %s to set source pipe\n", h.Name())
 	}
 
 	if !ok {
@@ -194,9 +194,9 @@ func (h *hub) SetSource(port interface{}, s Stream) Hub {
 
 }
 
-// SetResult sets a stream on a result port selected by string or int
-func (h *hub) SetResult(port interface{}, s Stream) Hub {
-	checkInternalStream(h.Flowgraph(), s)
+// SetResult sets a pipe on a result port selected by string or int
+func (h *hub) SetResult(port interface{}, s Pipe) Hub {
+	checkInternalPipe(h.Flowgraph(), s)
 
 	var i int
 	var ok bool
@@ -208,7 +208,7 @@ func (h *hub) SetResult(port interface{}, s Stream) Hub {
 		ok = v >= 0 && v < h.NumResult()
 		i = v
 	default:
-		h.Panicf("Need string or int to select result port on hub %s to set result stream\n", h.Name())
+		h.Panicf("Need string or int to select result port on hub %s to set result pipe\n", h.Name())
 	}
 
 	if !ok {
@@ -221,19 +221,19 @@ func (h *hub) SetResult(port interface{}, s Stream) Hub {
 	return h
 }
 
-// AddSources adds a source port for each stream
-func (h *hub) AddSources(s ...Stream) Hub {
+// AddSources adds a source port for each pipe
+func (h *hub) AddSources(s ...Pipe) Hub {
 	for _, sv := range s {
-		checkInternalStream(h.Flowgraph(), sv)
+		checkInternalPipe(h.Flowgraph(), sv)
 		h.Base().(*fgbase.Node).SrcAppend(sv.Base().(*fgbase.Edge))
 	}
 	return h
 }
 
-// AddResults adds a result port for each stream
-func (h *hub) AddResults(s ...Stream) Hub {
+// AddResults adds a result port for each pipe
+func (h *hub) AddResults(s ...Pipe) Hub {
 	for _, sv := range s {
-		checkInternalStream(h.Flowgraph(), sv)
+		checkInternalPipe(h.Flowgraph(), sv)
 		h.Base().(*fgbase.Node).DstAppend(sv.Base().(*fgbase.Edge))
 	}
 	return h
@@ -283,7 +283,7 @@ func (h *hub) SetResultNames(nm ...string) Hub {
 	return h
 }
 
-// SourceIndex returns the index of a source port selected by string or stream
+// SourceIndex returns the index of a source port selected by string or pipe
 func (h *hub) SourceIndex(port interface{}) int {
 	var i int
 	var ok bool
@@ -292,7 +292,7 @@ func (h *hub) SourceIndex(port interface{}) int {
 		i, ok = h.base.FindSrcIndex(v)
 	case int:
 		i, ok = v, true
-	case Stream:
+	case Pipe:
 		for j := 0; j < h.NumSource(); j++ {
 			if v.Same(h.Source(j)) {
 				i, ok = j, true
@@ -300,11 +300,11 @@ func (h *hub) SourceIndex(port interface{}) int {
 			}
 		}
 		if !ok {
-			h.Panicf("Source port for Stream %s not found on Hub %s\n", v.Name(), h.Name())
+			h.Panicf("Source port for Pipe %s not found on Hub %s\n", v.Name(), h.Name())
 		}
 
 	default:
-		h.Panicf("Need string, int or Stream to select port on Hub %s\n", h.Name())
+		h.Panicf("Need string, int or Pipe to select port on Hub %s\n", h.Name())
 	}
 
 	if !ok {
@@ -313,7 +313,7 @@ func (h *hub) SourceIndex(port interface{}) int {
 	return i
 }
 
-// ResultIndex returns the index of a result port selected by string or stream
+// ResultIndex returns the index of a result port selected by string or pipe
 func (h *hub) ResultIndex(port interface{}) int {
 	var i int
 	var ok bool
@@ -322,7 +322,7 @@ func (h *hub) ResultIndex(port interface{}) int {
 		i, ok = h.base.FindDstIndex(v)
 	case int:
 		i, ok = v, true
-	case Stream:
+	case Pipe:
 		for j := 0; j < h.NumResult(); j++ {
 			if v.Same(h.Result(j)) {
 				i, ok = j, true
@@ -330,11 +330,11 @@ func (h *hub) ResultIndex(port interface{}) int {
 			}
 		}
 		if !ok {
-			h.Panicf("Result port for Stream %s not found on Hub %s\n", v.Name(), h.Name())
+			h.Panicf("Result port for Pipe %s not found on Hub %s\n", v.Name(), h.Name())
 		}
 
 	default:
-		h.Panicf("Need string, int or Stream to select port on Hub %s\n", h.Name())
+		h.Panicf("Need string, int or Pipe to select port on Hub %s\n", h.Name())
 	}
 
 	if !ok {
@@ -343,8 +343,8 @@ func (h *hub) ResultIndex(port interface{}) int {
 	return i
 }
 
-// ConnectSources connects a list of source streams to this hub
-func (h *hub) ConnectSources(source ...Stream) Hub {
+// ConnectSources connects a list of source pipes to this hub
+func (h *hub) ConnectSources(source ...Pipe) Hub {
 	h.SetNumSource(len(source))
 	for i, v := range source {
 		h.SetSource(i, v)
@@ -352,8 +352,8 @@ func (h *hub) ConnectSources(source ...Stream) Hub {
 	return h
 }
 
-// ConnectResults connects a list of result streams to this hub
-func (h *hub) ConnectResults(result ...Stream) Hub {
+// ConnectResults connects a list of result pipes to this hub
+func (h *hub) ConnectResults(result ...Pipe) Hub {
 	h.SetNumResult(len(result))
 	for i, v := range result {
 		h.SetResult(i, v)

--- a/pipe.go
+++ b/pipe.go
@@ -6,13 +6,13 @@ import (
 
 import ()
 
-// Stream interface for flowgraph streams that connect flowgraph hubs
-type Stream interface {
+// Pipe interface for flowgraph pipes that connect flowgraph hubs
+type Pipe interface {
 
-	// Name returns the stream name
+	// Name returns the pipe name
 	Name() string
 
-	// SetName sets the stream name
+	// SetName sets the pipe name
 	SetName(name string)
 
 	// Upstream returns upstream hub by index
@@ -28,22 +28,22 @@ type Stream interface {
 	NumDownstream() int
 
 	// Init sets an initial value for flow
-	Init(v interface{}) Stream
+	Init(v interface{}) Pipe
 
 	// Const sets a value for continual flow
-	Const(v interface{}) Stream
+	Const(v interface{}) Pipe
 
-	// Sink sets a stream to be a sink
-	Sink() Stream
+	// Sink sets a pipe to be a sink
+	Sink() Pipe
 
-	// IsConst returns true if stream is a constant
+	// IsConst returns true if pipe is a constant
 	IsConst() bool
 
-	// IsSink returns true if stream is a sink
+	// IsSink returns true if pipe is a sink
 	IsSink() bool
 
-	// Same returns true if two streams are the same underneath
-	Same(Stream) bool
+	// Same returns true if two pipes are the same underneath
+	Same(Pipe) bool
 
 	// Empty returns true if the underlying implementation is nil
 	Empty() bool
@@ -55,24 +55,24 @@ type Stream interface {
 	Base() interface{}
 }
 
-// Stream implementation
-type stream struct {
+// Pipe implementation
+type pipe struct {
 	base *fgbase.Edge
 	fg   *flowgraph
 }
 
-// Name returns the stream name
-func (s *stream) Name() string {
+// Name returns the pipe name
+func (s *pipe) Name() string {
 	return s.base.Name
 }
 
-// SetName sets the stream name
-func (s *stream) SetName(name string) {
+// SetName sets the pipe name
+func (s *pipe) SetName(name string) {
 	s.base.SetName(name)
 }
 
 // Upstream returns upstream hub by index
-func (s *stream) Upstream(i int) Hub {
+func (s *pipe) Upstream(i int) Hub {
 	if s.base != nil && s.base.SrcNode(i) != nil {
 		return s.base.SrcNode(i).Owner.(Hub)
 	}
@@ -80,7 +80,7 @@ func (s *stream) Upstream(i int) Hub {
 }
 
 // Downstream returns upstream hub by index
-func (s *stream) Downstream(i int) Hub {
+func (s *pipe) Downstream(i int) Hub {
 	if s.base != nil && s.base.DstNode(i) != nil {
 		return s.base.DstNode(i).Owner.(Hub)
 	}
@@ -88,46 +88,46 @@ func (s *stream) Downstream(i int) Hub {
 }
 
 // NumUpstream returns the number of upstream hubs
-func (s *stream) NumUpstream() int {
+func (s *pipe) NumUpstream() int {
 	return s.base.SrcCnt()
 }
 
 // NumDownstream returns the number of downstream hubs
-func (s *stream) NumDownstream() int {
+func (s *pipe) NumDownstream() int {
 	return s.base.DstCnt()
 }
 
 // Init sets an initial value for flow
-func (s *stream) Init(v interface{}) Stream {
+func (s *pipe) Init(v interface{}) Pipe {
 	s.Base().(*fgbase.Edge).Val = v
 	return s
 }
 
 // Const sets a value for continual flow
-func (s *stream) Const(v interface{}) Stream {
+func (s *pipe) Const(v interface{}) Pipe {
 	s.Base().(*fgbase.Edge).Const(v)
 	return s
 }
 
-// Sink sets a stream to be a sink
-func (s *stream) Sink() Stream {
+// Sink sets a pipe to be a sink
+func (s *pipe) Sink() Pipe {
 	s.Base().(*fgbase.Edge).Sink()
 	return s
 }
 
-// IsConst returns true if stream is a constant
-func (s *stream) IsConst() bool {
+// IsConst returns true if pipe is a constant
+func (s *pipe) IsConst() bool {
 	return s.Base().(*fgbase.Edge).IsConst()
 }
 
-// IsSink returns true if stream is a sink
-func (s *stream) IsSink() bool {
+// IsSink returns true if pipe is a sink
+func (s *pipe) IsSink() bool {
 	return s.Base().(*fgbase.Edge).IsSink()
 }
 
-// Same returns true if two streams are the same underneath
-func (s *stream) Same(s2 Stream) bool {
-	checkInternalStream(s.fg, s2)
+// Same returns true if two pipes are the same underneath
+func (s *pipe) Same(s2 Pipe) bool {
+	checkInternalPipe(s.fg, s2)
 
 	if s.Base().(*fgbase.Edge) == nil {
 		return s2.Base().(*fgbase.Edge) == nil
@@ -139,16 +139,16 @@ func (s *stream) Same(s2 Stream) bool {
 }
 
 // Empty returns true if the underlying implementation is nil
-func (s *stream) Empty() bool {
+func (s *pipe) Empty() bool {
 	return s.base == nil
 }
 
 // Flowgraph returns associate flowgraph interface
-func (s *stream) Flowgraph() Flowgraph {
+func (s *pipe) Flowgraph() Flowgraph {
 	return s.fg
 }
 
 // Base returns value of underlying implementation
-func (s *stream) Base() interface{} {
+func (s *pipe) Base() interface{} {
 	return s.base
 }

--- a/pipe.go
+++ b/pipe.go
@@ -6,6 +6,10 @@ import (
 
 import ()
 
+// Renamed Stream to Pipe: honors Doug McIlroy's Unix pipes, names what
+// actually connects to a hub (not the stream flowing within it), and marks
+// real backpressure -- unlike streams, which can overflow and cause havoc.
+
 // Pipe interface for flowgraph pipes that connect flowgraph hubs
 type Pipe interface {
 


### PR DESCRIPTION
## Summary
- Renames the `Stream` type to `Pipe` throughout the package (interface, struct, methods, fields, file `stream.go` -> `pipe.go`) -- text and prose references too.
- `Upstream`/`Downstream`/`dnstream` left untouched -- those name flow direction, not the renamed type.
- Adds a short comment on `Pipe` explaining the rename (McIlroy's Unix pipes, names what connects to a hub rather than what flows through it, and marks real backpressure vs. a stream that can overflow).
- Adds `AGENTS.md`: commenting-discipline conventions for this repo (short, judicious comments; no issue/PR references in source; don't restate what identifiers already say).

## Test plan
- [x] `go build .` and `go test ./...` pass (pre-existing `examples/` multi-`package main` build failure and one `go vet` unreachable-code warning are unrelated, present on `master` too)
- [x] Confirmed no `examples/`/`duckpond/` source references `Stream` as an identifier (they only chain through methods without naming the type), so nothing there needed updating