### PR TITLE
Fix EOF type mismatch across fgbase/flowgraph boundary in AllOf/OneOf hubs

### DIFF
--- a/flowgraph.go
+++ b/flowgraph.go
@@ -498,7 +498,7 @@ func allOfFire(n *fgbase.Node) error {
 	eofflag := false
 	for i, _ := range a {
 		a[i] = n.Srcs[i].SrcGet()
-		if v, ok := a[i].(error); ok && v == EOF {
+		if v, ok := a[i].(error); ok && v.Error() == "EOF" {
 			n.Srcs[i].Flow = false
 			eofflag = true
 		}
@@ -549,7 +549,7 @@ func oneOfFire(n *fgbase.Node) error {
 	for i, _ := range a {
 		if n.Srcs[i].SrcRdy(n) {
 			a[i] = n.Srcs[i].SrcGet()
-			if v, ok := a[i].(error); ok && v == EOF {
+			if v, ok := a[i].(error); ok && v.Error() == "EOF" {
 				n.Srcs[i].Flow = false
 				eofflag = true
 			}

--- a/flowgraph.go
+++ b/flowgraph.go
@@ -6,20 +6,18 @@ package flowgraph
 import (
 	"github.com/vectaport/fgbase"
 
+	"errors"
 	"flag"
 	"fmt"
 	"log"
 )
 
-type Error string
-
-func (e Error) Error() string {
-	return string(e)
-}
-
-// End of flow. Transmitted when end-of-file occurs, and promises no more
-// data to follow.
-const EOF = Error("EOF")
+// EOF is flowgraph's own name for fgbase.EOS -- the same value, not a
+// separate one, so a Transform/Retrieve/Transmit implementation can
+// return flowgraph.EOF and have it recognized as end-of-stream by any
+// fgbase-native hub, and vice versa. Transmitted when end-of-file
+// occurs, and promises no more data to follow.
+var EOF = fgbase.EOS
 
 var flatDot = false
 
@@ -498,7 +496,7 @@ func allOfFire(n *fgbase.Node) error {
 	eofflag := false
 	for i, _ := range a {
 		a[i] = n.Srcs[i].SrcGet()
-		if v, ok := a[i].(error); ok && v.Error() == "EOF" {
+		if v, ok := a[i].(error); ok && errors.Is(v, fgbase.EOS) {
 			n.Srcs[i].Flow = false
 			eofflag = true
 		}
@@ -549,7 +547,7 @@ func oneOfFire(n *fgbase.Node) error {
 	for i, _ := range a {
 		if n.Srcs[i].SrcRdy(n) {
 			a[i] = n.Srcs[i].SrcGet()
-			if v, ok := a[i].(error); ok && v.Error() == "EOF" {
+			if v, ok := a[i].(error); ok && errors.Is(v, fgbase.EOS) {
 				n.Srcs[i].Flow = false
 				eofflag = true
 			}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/vectaport/flowgraph
 
 go 1.20
 
-require github.com/vectaport/fgbase v0.0.0-20200618171749-65072ea6a76e
+require github.com/vectaport/fgbase v0.0.0-20260716061424-0199321852c5
 
 require (
 	golang.org/x/crypto v0.9.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/vectaport/flowgraph
 
 go 1.20
 
-require github.com/vectaport/fgbase v0.0.0-20260716061424-0199321852c5
+require github.com/vectaport/fgbase v0.0.0-20260716134424-1f34c201c5d2
 
 require (
 	golang.org/x/crypto v0.9.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/vectaport/flowgraph
 
 go 1.20
 
-require github.com/vectaport/fgbase v0.0.0-20260716134424-1f34c201c5d2
+require github.com/vectaport/fgbase v0.0.0-20260716185028-5afd58281402
 
 require (
 	golang.org/x/crypto v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/vectaport/fgbase v0.0.0-20260716134424-1f34c201c5d2 h1:CVUbfqFw9S/0Gm96Zn/D6OlB1g9EO0CB/4wRL2ihYQg=
-github.com/vectaport/fgbase v0.0.0-20260716134424-1f34c201c5d2/go.mod h1:HJv3gGKooVbuxPC+A5EiI+hCtTc17yobJefj2Kxl29A=
+github.com/vectaport/fgbase v0.0.0-20260716185028-5afd58281402 h1:M4PMoa4adyILD2iui9BMz3Hrl2LxWiXCJcrINFIrAes=
+github.com/vectaport/fgbase v0.0.0-20260716185028-5afd58281402/go.mod h1:HJv3gGKooVbuxPC+A5EiI+hCtTc17yobJefj2Kxl29A=
 golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=
 golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/vectaport/fgbase v0.0.0-20260716061424-0199321852c5 h1:wbmOr5czoXqQ3mLYwpEQIwb+XG1gi9+M3Lb5nEFCd9M=
-github.com/vectaport/fgbase v0.0.0-20260716061424-0199321852c5/go.mod h1:HJv3gGKooVbuxPC+A5EiI+hCtTc17yobJefj2Kxl29A=
+github.com/vectaport/fgbase v0.0.0-20260716134424-1f34c201c5d2 h1:CVUbfqFw9S/0Gm96Zn/D6OlB1g9EO0CB/4wRL2ihYQg=
+github.com/vectaport/fgbase v0.0.0-20260716134424-1f34c201c5d2/go.mod h1:HJv3gGKooVbuxPC+A5EiI+hCtTc17yobJefj2Kxl29A=
 golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=
 golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/vectaport/fgbase v0.0.0-20200618171749-65072ea6a76e h1:n4JiydP0Hjg9XmEySYLENy1x2HLHPaanrCcBByZI70w=
-github.com/vectaport/fgbase v0.0.0-20200618171749-65072ea6a76e/go.mod h1:PyCoFUIaixAA1ViMtum2UND39rGeJGmeeW9jCNDMTkg=
+github.com/vectaport/fgbase v0.0.0-20260716061424-0199321852c5 h1:wbmOr5czoXqQ3mLYwpEQIwb+XG1gi9+M3Lb5nEFCd9M=
+github.com/vectaport/fgbase v0.0.0-20260716061424-0199321852c5/go.mod h1:HJv3gGKooVbuxPC+A5EiI+hCtTc17yobJefj2Kxl29A=
 golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=
 golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=


### PR DESCRIPTION
## Summary
- `fgbase.Error` and `flowgraph.Error` are separate `type Error string` declarations, one per package. `fgbase.EOF` and `flowgraph.EOF` stringify identically ("EOF") but are different dynamic types once boxed into an `error` interface, so `v == EOF` is always false when `v` is an fgbase-native EOF value compared against flowgraph's own `EOF` constant.
- `fgbase`-level source hubs (e.g. `Array`, via `fgbase.ArrayFire`) emit `fgbase.EOF`. `allOfFire`/`oneOfFire` (used by every `AllOf`/`OneOf` hub, including plain `pass`-style Transform hubs) checked `v == EOF` against `flowgraph.EOF` -- so they never recognized it. They forwarded the sentinel as if it were ordinary data and returned `nil` instead of the EOF error, so the hub's goroutine never exited -- it just looped forever waiting for more input.
- `fgbase.SinkFire` already gets this right (`v.Error() == "EOF"`, a string comparison immune to the type mismatch). This brings `allOfFire`/`oneOfFire` in line with it.

## Confirmed with a standalone repro
Built a probe replicating `TestChain`'s graph (`Array` -> 16x `AllOf`/pass -> `Sink`) with `fgbase.RunTime = 0` (forcing an unconditional wait for every node goroutine to exit). Before this fix: real deadlock -- every pass node except `Sink` stuck forever waiting for an ack `Sink` correctly withheld, because `Sink` alone recognized EOF (via its string-based check). After this fix: returns in under 1ms with the correct result (`Cnt=10, Sum=45`).

## Depends on fgbase#4
This fix alone does **not** close the CI race in this repo's `-race` step. It needs [fgbase#4](https://github.com/vectaport/fgbase/pull/4) (`runAll` racing its `RunTime` deadline against `wg.Wait()` instead of always sleeping the full deadline blind) landed alongside it -- without that, `runAll` never actually waits to observe the graph finished, so it still gets abandoned at the deadline regardless of whether this EOF fix lets it terminate gracefully.

With both fixes applied (verified locally via a `go.mod` replace directive), `TestChain` finishes in `0.01s` instead of `1.00s`, and the specific `TestChain`/`TestDotNaming` cross-test race is gone. A *different*, same-root-cause race remains on graphs using non-terminating sources like `Constant` (which, like `examples/loop*.go`, never emits EOF by design and so still correctly falls back to the deadline) -- that's a separate, bigger gap (no real cancellation mechanism for `Node.Run()`) tracked as follow-up, not introduced or worsened by this fix.

## Test plan
- [x] `go build .` / `go vet .` clean
- [x] Standalone probe: deadlock before, clean exit after
- [x] Verified against fgbase#4 via `go.mod` replace directive: `TestChain` 1.00s -> 0.01s, targeted race gone
- [ ] Land alongside fgbase#4, then bump this repo's `go.mod` to the merged fgbase commit as a follow-up