### PR TITLE
set flowgraph.EOS to fgbase.EOS (not flowgraph.EOF)

### DIFF
--- a/examples/gcd.go
+++ b/examples/gcd.go
@@ -30,7 +30,7 @@ func (t *rand100) Retrieve(n flowgraph.Hub) (result interface{}, err error) {
 		// (*t).init = true
 		return rand.Intn(100) + 1, nil
 	}
-	return flowgraph.EOF, flowgraph.EOF
+	return flowgraph.EOS, flowgraph.EOS
 }
 
 func main() {

--- a/flowgraph.go
+++ b/flowgraph.go
@@ -12,12 +12,12 @@ import (
 	"log"
 )
 
-// EOF is flowgraph's own name for fgbase.EOS -- the same value, not a
+// EOS is flowgraph's own name for fgbase.EOS -- the same value, not a
 // separate one, so a Transform/Retrieve/Transmit implementation can
-// return flowgraph.EOF and have it recognized as end-of-stream by any
+// return flowgraph.EOS and have it recognized as end-of-stream by any
 // fgbase-native hub, and vice versa. Transmitted when end-of-file
 // occurs, and promises no more data to follow.
-var EOF = fgbase.EOS
+var EOS = fgbase.EOS
 
 var flatDot = false
 
@@ -504,7 +504,7 @@ func allOfFire(n *fgbase.Node) error {
 	x, _ := t.Transform(&hub{n, fg, AllOf}, a)
 	for i, _ := range x {
 		if eofflag {
-			n.Dsts[i].DstPut(EOF)
+			n.Dsts[i].DstPut(EOS)
 		} else {
 			if x[i] != nil {
 				n.Dsts[i].DstPut(x[i])
@@ -512,7 +512,7 @@ func allOfFire(n *fgbase.Node) error {
 		}
 	}
 	if eofflag {
-		return EOF
+		return EOS
 	} else {
 		return nil
 	}
@@ -557,7 +557,7 @@ func oneOfFire(n *fgbase.Node) error {
 	x, _ := t.Transform(&hub{n, fg, OneOf}, a)
 	for i, _ := range x {
 		if eofflag {
-			n.Dsts[i].DstPut(EOF)
+			n.Dsts[i].DstPut(EOS)
 		} else {
 			if x[i] != nil {
 				n.Dsts[i].DstPut(x[i])
@@ -565,7 +565,7 @@ func oneOfFire(n *fgbase.Node) error {
 		}
 	}
 	if eofflag {
-		return EOF
+		return EOS
 	} else {
 		return nil
 	}

--- a/flowgraph_test.go
+++ b/flowgraph_test.go
@@ -1107,7 +1107,7 @@ func (t *rand100) Retrieve(n flowgraph.Hub) (result interface{}, err error) {
 		// (*t).init = true
 		return rand.Intn(100) + 1, nil
 	}
-	return flowgraph.EOF, flowgraph.EOF
+	return flowgraph.EOS, flowgraph.EOS
 }
 
 func TestGCD(t *testing.T) {

--- a/hubcode.go
+++ b/hubcode.go
@@ -22,7 +22,7 @@ const (
 	Steer  // 	nil		2|1,2	steer last source by first source
 	Cross  // 	nil           2*n,2*n   steer left or right rank by first source of each
 
-	Array    //	[]interface{}	0,1	produce array of values then EOF
+	Array    //	[]interface{}	0,1	produce array of values then EOS
 	Constant //	interface{}	0,1	produce constant values forever
 	Pass     //	nil		1,1	pass value
 	Split    //	nil		1,n     split slice into values


### PR DESCRIPTION
# set flowgraph.EOS to fgbase.EOS (not flowgraph.EOF)

fgbase.EOS is the original error for end-of-stream in flow graphs (not to be confused with io.EOF).  flowgraph.EOF was set up to be the same same fgbase.EOS, but it makes sense to call it flowgraph.EOS as well.