### PR TITLE
Bump fgbase to cancel-on-shutdown branch (fgbase#5) -- verifies the remaining TestDotNaming leak fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/vectaport/flowgraph
 
 go 1.20
 
-require github.com/vectaport/fgbase v0.0.0-20260718162131-172f9e005733
+require github.com/vectaport/fgbase v0.0.0-20260718163615-72d78b54b9d8
 
 require (
-	golang.org/x/crypto v0.54.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/crypto v0.9.0 // indirect
+	golang.org/x/sys v0.8.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/vectaport/flowgraph
 
 go 1.20
 
-require github.com/vectaport/fgbase v0.0.0-20260718172349-2448656f90cb
+require github.com/vectaport/fgbase v0.0.0-20260718190341-bc200363d0b2
 
 require (
 	golang.org/x/crypto v0.9.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/vectaport/flowgraph
 
 go 1.20
 
-require github.com/vectaport/fgbase v0.0.0-20260716185028-5afd58281402
+require github.com/vectaport/fgbase v0.0.0-20260717161916-e9066dbe35b2
 
 require (
 	golang.org/x/crypto v0.9.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/vectaport/flowgraph
 
 go 1.20
 
-require github.com/vectaport/fgbase v0.0.0-20260717161916-e9066dbe35b2
+require github.com/vectaport/fgbase v0.0.0-20260718162131-172f9e005733
 
 require (
-	golang.org/x/crypto v0.9.0 // indirect
-	golang.org/x/sys v0.8.0 // indirect
+	golang.org/x/crypto v0.54.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/vectaport/flowgraph
 
 go 1.20
 
-require github.com/vectaport/fgbase v0.0.0-20260718163615-72d78b54b9d8
+require github.com/vectaport/fgbase v0.0.0-20260718172349-2448656f90cb
 
 require (
 	golang.org/x/crypto v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-github.com/vectaport/fgbase v0.0.0-20260717161916-e9066dbe35b2 h1:PDEAn2x3ongmsqUsTXQfMWFg5kI3MhCKHZawPhjaf9s=
-github.com/vectaport/fgbase v0.0.0-20260717161916-e9066dbe35b2/go.mod h1:HJv3gGKooVbuxPC+A5EiI+hCtTc17yobJefj2Kxl29A=
-golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=
-golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0=
-golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
-golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+github.com/vectaport/fgbase v0.0.0-20260718162131-172f9e005733 h1:4JBU2JybKfTlQwnFKn3b+3vGP3eRuh2L9xOIUDaShXo=
+github.com/vectaport/fgbase v0.0.0-20260718162131-172f9e005733/go.mod h1:qIbHrzk6ecDvOgpXLgYlRLZQxIGHtbXF9ntfC4PW7+o=
+golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
+golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/vectaport/fgbase v0.0.0-20260718172349-2448656f90cb h1:THCvHg/jiqK2y7CSC8sUc4BM51MIuJHKH/q87h2oVwE=
-github.com/vectaport/fgbase v0.0.0-20260718172349-2448656f90cb/go.mod h1:XM5JKp2uMBzQ4vBt21ekvPWh30YtNte4pZo+6gYmapg=
+github.com/vectaport/fgbase v0.0.0-20260718190341-bc200363d0b2 h1:ZmaSqt6pHv6XQzVLdABRU4QrHkkzej9oGKR/N5yP5LU=
+github.com/vectaport/fgbase v0.0.0-20260718190341-bc200363d0b2/go.mod h1:XM5JKp2uMBzQ4vBt21ekvPWh30YtNte4pZo+6gYmapg=
 golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=
 golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/vectaport/fgbase v0.0.0-20260718163615-72d78b54b9d8 h1:FXJfWCNRRoA6ihRVD7ThVFqot4TmrMXXckMnVyxQlXI=
-github.com/vectaport/fgbase v0.0.0-20260718163615-72d78b54b9d8/go.mod h1:XM5JKp2uMBzQ4vBt21ekvPWh30YtNte4pZo+6gYmapg=
+github.com/vectaport/fgbase v0.0.0-20260718172349-2448656f90cb h1:THCvHg/jiqK2y7CSC8sUc4BM51MIuJHKH/q87h2oVwE=
+github.com/vectaport/fgbase v0.0.0-20260718172349-2448656f90cb/go.mod h1:XM5JKp2uMBzQ4vBt21ekvPWh30YtNte4pZo+6gYmapg=
 golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=
 golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-github.com/vectaport/fgbase v0.0.0-20260718162131-172f9e005733 h1:4JBU2JybKfTlQwnFKn3b+3vGP3eRuh2L9xOIUDaShXo=
-github.com/vectaport/fgbase v0.0.0-20260718162131-172f9e005733/go.mod h1:qIbHrzk6ecDvOgpXLgYlRLZQxIGHtbXF9ntfC4PW7+o=
-golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
-golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
-golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
-golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+github.com/vectaport/fgbase v0.0.0-20260718163615-72d78b54b9d8 h1:FXJfWCNRRoA6ihRVD7ThVFqot4TmrMXXckMnVyxQlXI=
+github.com/vectaport/fgbase v0.0.0-20260718163615-72d78b54b9d8/go.mod h1:XM5JKp2uMBzQ4vBt21ekvPWh30YtNte4pZo+6gYmapg=
+golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=
+golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0=
+golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
+golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/vectaport/fgbase v0.0.0-20260716185028-5afd58281402 h1:M4PMoa4adyILD2iui9BMz3Hrl2LxWiXCJcrINFIrAes=
-github.com/vectaport/fgbase v0.0.0-20260716185028-5afd58281402/go.mod h1:HJv3gGKooVbuxPC+A5EiI+hCtTc17yobJefj2Kxl29A=
+github.com/vectaport/fgbase v0.0.0-20260717161916-e9066dbe35b2 h1:PDEAn2x3ongmsqUsTXQfMWFg5kI3MhCKHZawPhjaf9s=
+github.com/vectaport/fgbase v0.0.0-20260717161916-e9066dbe35b2/go.mod h1:HJv3gGKooVbuxPC+A5EiI+hCtTc17yobJefj2Kxl29A=
 golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=
 golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=


### PR DESCRIPTION
## Summary
Temporary pin to verify [fgbase#5](https://github.com/vectaport/fgbase/pull/5) (real cancellation for `Node.Run`, closing the goroutine-leak gap that #4's `wg.Wait()`-vs-deadline fix didn't reach for non-terminating graphs like `Constant`->`Sink`). No code changes in this repo -- entirely internal to fgbase.

## Test plan
- [x] `go build .` / `go vet .` clean against the pinned commit
- [x] `TestChain`/`TestDotNaming` pass under `-race`
- [ ] Land alongside fgbase#5, then bump to master's merged commit as a follow-up (drop the TEMPORARY pin)